### PR TITLE
Add qcow2 as supported format by xcp-rrdd-iostat

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -365,7 +365,8 @@ let refresh_phypath_to_sr_vdi () =
 let exec_tap_ctl_list () : ((string * string) * int) list =
   let tap_ctl = "/usr/sbin/tap-ctl list" in
   let extract_vdis pid minor _state kind phypath =
-    if not (kind = "vhd" || kind = "aio") then raise (Failure "Unknown type") ;
+    if not (kind = "vhd" || kind = "aio" || kind = "qcow2") then
+      raise (Failure "Unknown type") ;
     (* Look up SR and VDI uuids from the physical path *)
     if not (Hashtbl.mem phypath_to_sr_vdi phypath) then
       refresh_phypath_to_sr_vdi () ;


### PR DESCRIPTION
Since we are now supporting qcow file `tap-ctl list` can return strings like:
  - "1564848    0    0      qcow2 /var/run/sr-mount/..."
Without this patch the type "qcow2" is unknown and xcp-rrdd-iostat generates an
error like: returned a line that could not be parsed. Ignoring
This patch fixes the issue.