### PR TITLE
Add qcow2 as supported format by xcp-rrdd-iostat

### DIFF
--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -109,6 +109,7 @@ let generate_pub_priv_key length =
       let stdout, _stderr = call_openssl args in
       Ok stdout
     with e ->
+      Backtrace.is_important e ;
       let msg = "generating RSA key failed" in
       D.error "selfcert.ml: %s" msg ;
       Debug.log_backtrace e (Backtrace.get e) ;

--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -204,7 +204,7 @@ let t =
              (Some (VString Constants.default_smapiv3_cluster_stack))
            "Simply the string 'corosync'. No other cluster stacks are \
             currently supported"
-       ; field ~qualifier:StaticRO ~lifecycle ~ty:Int "cluster_stack_version"
+       ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:Int "cluster_stack_version"
            ~default_value:(Some (VInt 2L))
            "Version of cluster stack, not writable via the API. Defaulting to \
             2 for backwards compatibility when upgrading from a cluster \

--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -219,6 +219,9 @@ let t =
        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "live_hosts"
            ~default_value:(Some (VInt 0L))
            "Current number of live hosts, according to the cluster stack"
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "expected_hosts"
+           ~default_value:(Some (VInt 0L))
+           "Total number of hosts expected by the cluster stack"
        ]
       @ allowed_and_current_operations cluster_operation
       @ [

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 788
+let schema_minor_vsn = 789
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -77,6 +77,8 @@ let prototyped_of_field = function
       Some "24.3.0"
   | "Cluster_host", "live" ->
       Some "24.3.0"
+  | "Cluster", "expected_hosts" ->
+      Some "25.16.0-next"
   | "Cluster", "live_hosts" ->
       Some "24.3.0"
   | "Cluster", "quorum" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -126,7 +126,7 @@ let prototyped_of_field = function
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
   | "pool", "ha_reboot_vm_on_internal_shutdown" ->
-      Some "25.15.0-next"
+      Some "25.16.0"
   | "pool", "license_server" ->
       Some "25.6.0"
   | "pool", "recommendations" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -83,6 +83,8 @@ let prototyped_of_field = function
       Some "24.3.0"
   | "Cluster", "is_quorate" ->
       Some "24.3.0"
+  | "Cluster", "cluster_stack_version" ->
+      Some "24.15.0"
   | "VTPM", "contents" ->
       Some "22.26.0"
   | "VTPM", "is_protected" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "e10b420b0863116ee188eea9e63b1349"
+let last_known_schema_hash = "0cf3458af211661024fca9c1d0ab34ab"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "0cf3458af211661024fca9c1d0ab34ab"
+let last_known_schema_hash = "2f80cd8fbfd0eedab4dfe345565bcb64"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -1,109 +1,103 @@
 (library
-  (name http_lib)
-  (public_name http-lib)
-  (modes best)
-  (wrapped false)
-  (modules (:standard \ http_svr http_proxy server_io http_test radix_tree_test test_client test_server))
-  (preprocess (per_module ((pps ppx_deriving_rpc) Http)))
-  (libraries
-    astring
-    base64
-    fmt
-    ipaddr
-    mtime
-    mtime.clock.os
-    rpclib.core
-    rpclib.json
-    rpclib.xml
-    safe_resources
-    sha
-    stunnel
-    threads.posix
-    uuid
-    uri
-    xapi-backtrace
-    xapi-consts.xapi_version
-    xapi-idl.updates
-    xapi-log
-    clock
-    xapi-stdext-pervasives
-    xapi-stdext-threads
-    xapi-stdext-unix
-    xml-light2
-  )
-)
+ (name http_lib)
+ (public_name http-lib)
+ (modes best)
+ (wrapped false)
+ (modules
+  (:standard
+   \
+   http_svr
+   http_proxy
+   server_io
+   http_test
+   radix_tree_test
+   test_client
+   test_server))
+ (preprocess
+  (per_module
+   ((pps ppx_deriving_rpc)
+    Http)))
+ (libraries
+  astring
+  base64
+  fmt
+  ipaddr
+  mtime
+  mtime.clock.os
+  rpclib.core
+  rpclib.json
+  rpclib.xml
+  safe_resources
+  sha
+  stunnel
+  threads.posix
+  uuid
+  uri
+  xapi-backtrace
+  xapi-consts.xapi_version
+  xapi-idl.updates
+  xapi-log
+  clock
+  xapi-stdext-pervasives
+  xapi-stdext-threads
+  xapi-stdext-unix
+  xml-light2))
 
 (library
-  (name httpsvr)
-  (wrapped false)
-  (modes best)
-  (modules http_svr http_proxy server_io)
-  (libraries
-    astring
-    http_lib
-    ipaddr
-    polly
-    tgroup
-    threads.posix
-    tracing
-    tracing_propagator
-    uri
-    xapi-log
-    xapi-stdext-pervasives
-    xapi-stdext-threads
-    xapi-stdext-unix
-  )
-)
+ (name httpsvr)
+ (wrapped false)
+ (modes best)
+ (modules http_svr http_proxy server_io)
+ (libraries
+  astring
+  http_lib
+  ipaddr
+  polly
+  tgroup
+  threads.posix
+  tracing
+  tracing_propagator
+  uri
+  xapi-backtrace
+  xapi-log
+  xapi-stdext-pervasives
+  xapi-stdext-threads
+  xapi-stdext-unix))
 
 (tests
-  (names http_test radix_tree_test)
-  (package http-lib)
-  (modes (best exe))
-  (modules http_test radix_tree_test)
-  (libraries
-    alcotest
-
-    fmt
-    http_lib
-  )
-)
+ (names http_test radix_tree_test)
+ (package http-lib)
+ (modes
+  (best exe))
+ (modules http_test radix_tree_test)
+ (libraries alcotest fmt http_lib))
 
 (executable
-  (modes exe)
-  (name test_client)
-  (modules test_client)
-  (libraries
-
-    http_lib
-    safe-resources
-    stunnel
-    threads.posix
-    xapi-backtrace
-    xapi-log
-    xapi-stdext-pervasives
-    xapi-stdext-unix
-  )
-)
+ (modes exe)
+ (name test_client)
+ (modules test_client)
+ (libraries
+  http_lib
+  safe-resources
+  stunnel
+  threads.posix
+  xapi-backtrace
+  xapi-log
+  xapi-stdext-pervasives
+  xapi-stdext-unix))
 
 (executable
-  (modes exe)
-  (name test_server)
-  (modules test_server)
-  (libraries
-
-    http_lib
-    httpsvr
-    safe-resources
-    threads.posix
-    xapi-stdext-threads
-    xapi-stdext-unix
-  )
-)
+ (modes exe)
+ (name test_server)
+ (modules test_server)
+ (libraries
+  http_lib
+  httpsvr
+  safe-resources
+  threads.posix
+  xapi-stdext-threads
+  xapi-stdext-unix))
 
 (cram
-  (package xapi)
-  (deps
-    test_client.exe
-    test_server.exe
-  )
-)
+ (package xapi)
+ (deps test_client.exe test_server.exe))

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -498,10 +498,8 @@ let read_request ?proxy_seen ~read_timeout ~total_timeout ~max_length fd =
                    (Unix.error_message a) b c
                 )
         | exc ->
-            Backtrace.is_important exc ;
             response_internal_error exc fd
-              ~extra:(escape (Printexc.to_string exc)) ;
-            log_backtrace exc
+              ~extra:(escape (Printexc.to_string exc))
     ) ;
     (None, None)
 

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -474,6 +474,7 @@ let read_request ?proxy_seen ~read_timeout ~total_timeout ~max_length fd =
     in
     (Some r, proxy)
   with e ->
+    Backtrace.is_important e ;
     D.warn "%s (%s)" (Printexc.to_string e) __LOC__ ;
     best_effort (fun () ->
         match e with

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -189,8 +189,9 @@ let response_request_header_fields_too_large s =
   response_error_html s "431" "Request Header Fields Too Large" [] body
 
 let response_internal_error ?req ?extra exc s =
+  Backtrace.is_important exc ;
   E.error "Responding with 500 Internal Error due to %s" (Printexc.to_string exc) ;
-  E.log_backtrace () ;
+  E.log_backtrace exc ;
   let version = Option.map get_return_version req in
   let extra =
     Option.fold ~none:""
@@ -497,9 +498,10 @@ let read_request ?proxy_seen ~read_timeout ~total_timeout ~max_length fd =
                    (Unix.error_message a) b c
                 )
         | exc ->
+            Backtrace.is_important exc ;
             response_internal_error exc fd
               ~extra:(escape (Printexc.to_string exc)) ;
-            log_backtrace ()
+            log_backtrace exc
     ) ;
     (None, None)
 

--- a/ocaml/libs/http-lib/server_io.ml
+++ b/ocaml/libs/http-lib/server_io.ml
@@ -53,12 +53,13 @@ let establish_server ?(signal_fds = []) forker handler sock =
              let s, caller = Unix.accept ~cloexec:true sock in
              try ignore (forker handler s caller)
              with exc ->
+               Backtrace.is_important exc ;
                (* NB provided 'forker' is configured to make a background thread then the
                   only way we can get here is if Thread.create fails.
                   This means we haven't executed any code which could close the fd therefore
                   we should do it ourselves. *)
                debug "Got exception in server_io.ml: %s" (Printexc.to_string exc) ;
-               log_backtrace () ;
+               log_backtrace exc ;
                Unix.close s ;
                Thread.delay 30.0
          )

--- a/ocaml/libs/log/debug.ml
+++ b/ocaml/libs/log/debug.ml
@@ -307,7 +307,7 @@ module type DEBUG = sig
 
   val audit : ?raw:bool -> ('a, unit, string, string) format4 -> 'a
 
-  val log_backtrace : unit -> unit
+  val log_backtrace : exn -> unit
 
   val log_and_ignore_exn : (unit -> unit) -> unit
 end
@@ -344,9 +344,10 @@ functor
         )
         fmt
 
-    let log_backtrace () =
-      let backtrace = Printexc.get_backtrace () in
-      debug "%s" (String.escaped backtrace)
+    let log_backtrace exn =
+      let level = Syslog.Debug in
+      if not (is_disabled Brand.name level) then
+        log_backtrace_internal ~level exn ()
 
     let log_and_ignore_exn f =
       try f ()

--- a/ocaml/libs/log/debug.ml
+++ b/ocaml/libs/log/debug.ml
@@ -258,6 +258,10 @@ let with_thread_associated ?client ?(quiet = false) desc f x =
       (* This function is a top-level exception handler typically used on fresh
          threads. This is the last chance to do something with the backtrace *)
       if not quiet then (
+        (* It would seem that a Backtrace.is_important would be missing here.
+           But in fact it has actually been called in [let result] above,
+           so calling it again is not necessary.
+        *)
         output_log "backtrace" Syslog.Err "error"
           (Printf.sprintf "%s failed with exception %s" desc
              (Printexc.to_string exn)

--- a/ocaml/libs/log/debug.mli
+++ b/ocaml/libs/log/debug.mli
@@ -76,7 +76,15 @@ module type DEBUG = sig
   val audit : ?raw:bool -> ('a, unit, string, string) format4 -> 'a
   (** Audit function *)
 
-  val log_backtrace : unit -> unit
+  val log_backtrace : exn -> unit
+  (** [log_backtrace exn] logs the backtrace associated with [exn].
+      Either this or {!Backtrace.is_important} must be the first statement in an exception handler,
+      otherwise the backtrace may be overwritten (e.g. by formatting functions that internally raise and catch exceptions).
+
+      This has to be used instead of getting a new backtrace from Printexc if [Backtrace.is_important] was ever called,
+      because that function stashes away the backtrace and then overwrites the current backtrace (to avoid duplicate frames in the stacktrace,
+      when Backtrace.get is used).
+   *)
 
   val log_and_ignore_exn : (unit -> unit) -> unit
 end

--- a/ocaml/libs/log/test/dune
+++ b/ocaml/libs/log/test/dune
@@ -1,0 +1,6 @@
+(executable
+ (name log_test)
+ (libraries log xapi-stdext-threads threads.posix xapi-backtrace))
+
+(cram
+ (deps log_test.exe))

--- a/ocaml/libs/log/test/log_test.ml
+++ b/ocaml/libs/log/test/log_test.ml
@@ -1,0 +1,17 @@
+module D = Debug.Make (struct let name = Filename.basename __FILE__ end)
+
+let m = Mutex.create ()
+
+let a = [||]
+
+let buggy () = a.(1) <- 0
+
+let () =
+  Printexc.record_backtrace true ;
+  Debug.log_to_stdout () ;
+  ()
+  |> Debug.with_thread_associated "main" @@ fun () ->
+     try Xapi_stdext_threads.Threadext.Mutex.execute m buggy
+     with e ->
+       D.log_backtrace () ;
+       D.warn "Got exception: %s" (Printexc.to_string e)

--- a/ocaml/libs/log/test/log_test.ml
+++ b/ocaml/libs/log/test/log_test.ml
@@ -13,5 +13,5 @@ let () =
   |> Debug.with_thread_associated "main" @@ fun () ->
      try Xapi_stdext_threads.Threadext.Mutex.execute m buggy
      with e ->
-       D.log_backtrace () ;
+       D.log_backtrace e ;
        D.warn "Got exception: %s" (Printexc.to_string e)

--- a/ocaml/libs/log/test/log_test.t
+++ b/ocaml/libs/log/test/log_test.t
@@ -1,4 +1,9 @@
   $ ./log_test.exe | sed -re 's/[0-9]+T[0-9:.]+Z//'
-  [|debug||0 |main|log_test.ml] Raised at Xapi_stdext_pervasives__Pervasiveext.finally in file \"ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml\", line 39, characters 6-15\nCalled from Dune__exe__Log_test.(fun) in file \"ocaml/libs/log/test/log_test.ml\", line 14, characters 9-60\n
+  [|error||0 |main|backtrace] Raised Invalid_argument("index out of bounds")
+  [|error||0 |main|backtrace] 1/4 log_test.exe Raised at file ocaml/libs/log/test/log_test.ml, line 7
+  [|error||0 |main|backtrace] 2/4 log_test.exe Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
+  [|error||0 |main|backtrace] 3/4 log_test.exe Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 39
+  [|error||0 |main|backtrace] 4/4 log_test.exe Called from file ocaml/libs/log/test/log_test.ml, line 14
+  [|error||0 |main|backtrace] 
   [| warn||0 |main|log_test.ml] Got exception: Invalid_argument("index out of bounds")
 

--- a/ocaml/libs/log/test/log_test.t
+++ b/ocaml/libs/log/test/log_test.t
@@ -1,0 +1,4 @@
+  $ ./log_test.exe | sed -re 's/[0-9]+T[0-9:.]+Z//'
+  [|debug||0 |main|log_test.ml] Raised at Xapi_stdext_pervasives__Pervasiveext.finally in file \"ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml\", line 39, characters 6-15\nCalled from Dune__exe__Log_test.(fun) in file \"ocaml/libs/log/test/log_test.ml\", line 14, characters 9-60\n
+  [| warn||0 |main|log_test.ml] Got exception: Invalid_argument("index out of bounds")
+

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -626,12 +626,13 @@ let make_cluster_and_cluster_host ~__context ?(ref = Ref.make ())
     ?(token_timeout = Constants.default_token_timeout_s)
     ?(token_timeout_coefficient = Constants.default_token_timeout_coefficient_s)
     ?(cluster_config = []) ?(other_config = []) ?(host = Ref.null)
-    ?(is_quorate = false) ?(quorum = 0L) ?(live_hosts = 0L) () =
+    ?(is_quorate = false) ?(quorum = 0L) ?(live_hosts = 0L)
+    ?(expected_hosts = 0L) () =
   Db.Cluster.create ~__context ~ref ~uuid ~cluster_token ~pending_forget:[]
     ~cluster_stack ~cluster_stack_version ~allowed_operations
     ~current_operations ~pool_auto_join ~token_timeout
     ~token_timeout_coefficient ~cluster_config ~other_config ~is_quorate ~quorum
-    ~live_hosts ;
+    ~live_hosts ~expected_hosts ;
   let cluster_host_ref =
     make_cluster_host ~__context ~cluster:ref ~host ~pIF ()
   in

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -69,6 +69,7 @@ let test_clusterd_rpc ~__context call =
         ; num_times_booted= 1
         ; is_quorate= true
         ; total_votes= 1
+        ; expected_votes= 1
         ; quorum= 1
         ; quorum_members= Some [me]
         ; is_running= true

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -24,7 +24,7 @@ let create_cluster ~__context pool_auto_join =
     ~token_timeout_coefficient:Constants.default_token_timeout_coefficient_s
     ~allowed_operations:[] ~current_operations:[] ~pool_auto_join
     ~cluster_config:[] ~other_config:[] ~pending_forget:[] ~is_quorate:false
-    ~quorum:0L ~live_hosts:0L ;
+    ~quorum:0L ~live_hosts:0L ~expected_hosts:0L ;
   cluster_ref
 
 let check_cluster_option =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4052,7 +4052,7 @@ let rio_help printer minimal cmd =
         in
         printer (Cli_printer.PTable [recs])
     | None ->
-        D.log_backtrace () ;
+        D.log_backtrace Not_found ;
         error "Responding with Unknown command %s" cmd ;
         printer (Cli_printer.PList ["Unknown command '" ^ cmd ^ "'"])
   in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4052,7 +4052,6 @@ let rio_help printer minimal cmd =
         in
         printer (Cli_printer.PTable [recs])
     | None ->
-        D.log_backtrace Not_found ;
         error "Responding with Unknown command %s" cmd ;
         printer (Cli_printer.PList ["Unknown command '" ^ cmd ^ "'"])
   in

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5132,6 +5132,9 @@ let cluster_record rpc session_id cluster =
       ; make_field ~name:"live-hosts"
           ~get:(fun () -> Int64.to_string (x ()).API.cluster_live_hosts)
           ()
+      ; make_field ~name:"expected-hosts"
+          ~get:(fun () -> Int64.to_string (x ()).API.cluster_expected_hosts)
+          ()
       ]
   }
 

--- a/ocaml/xapi-guard/lib/server_interface.ml
+++ b/ocaml/xapi-guard/lib/server_interface.ml
@@ -58,7 +58,7 @@ let with_xapi ~cache ?(timeout = 120.) f =
 let serve_forever_lwt path callback =
   let conn_closed _ = () in
   let on_exn e =
-    log_backtrace () ;
+    log_backtrace e ;
     warn "Exception: %s" (Printexc.to_string e)
   in
   let stop, do_stop = Lwt.task () in

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -299,7 +299,7 @@ let make_message_switch_server () =
         (* best effort resume *)
         let* () =
           Lwt.catch (resume ~vtpm_read_write ~uefi_read_write) (fun e ->
-              D.log_backtrace () ;
+              D.log_backtrace e ;
               D.warn "Resume failed: %s" (Printexc.to_string e) ;
               Lwt.return_unit
           )
@@ -321,7 +321,7 @@ let main log_level =
   let old_hook = !Lwt.async_exception_hook in
   (Lwt.async_exception_hook :=
      fun exn ->
-       D.log_backtrace () ;
+       D.log_backtrace exn ;
        D.error "Lwt caught async exception: %s" (Printexc.to_string exn) ;
        old_hook exn
   ) ;

--- a/ocaml/xapi-guard/test/xapi_guard_test.ml
+++ b/ocaml/xapi-guard/test/xapi_guard_test.ml
@@ -68,7 +68,7 @@ let () =
   let old_hook = !Lwt.async_exception_hook in
   Lwt.async_exception_hook :=
     fun exn ->
-      D.log_backtrace () ;
+      D.log_backtrace exn ;
       D.error "Lwt caught async exception: %s" (Printexc.to_string exn) ;
       old_hook exn
 

--- a/ocaml/xapi-idl/cluster/cluster_interface.ml
+++ b/ocaml/xapi-idl/cluster/cluster_interface.ml
@@ -159,6 +159,9 @@ type optional_path = string option [@@deriving rpcty]
 type quorum_info = {
     is_quorate: bool
   ; total_votes: int
+        (* number of nodes that the cluster stack thinks are currently in the cluster *)
+  ; expected_votes: int
+        (* number of nodes that the cluster stack is expecting to be in the cluster *)
   ; quorum: int  (** number of nodes required to form a quorum *)
   ; quorum_members: all_members option
 }
@@ -179,6 +182,7 @@ type diagnostics = {
   ; is_quorate: bool
   ; is_running: bool
   ; total_votes: int
+  ; expected_votes: int
   ; quorum: int
   ; quorum_members: all_members option
   ; startup_finished: bool

--- a/ocaml/xapi-idl/gpumon/gpumon_interface.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_interface.ml
@@ -87,8 +87,8 @@ let gpu_err =
       def= gpu_errors
     ; raiser=
         (fun e ->
-          log_backtrace () ;
           let exn = Gpumon_error e in
+          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/gpumon/gpumon_interface.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_interface.ml
@@ -88,7 +88,6 @@ let gpu_err =
     ; raiser=
         (fun e ->
           let exn = Gpumon_error e in
-          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/memory/memory_interface.ml
+++ b/ocaml/xapi-idl/memory/memory_interface.ml
@@ -87,8 +87,8 @@ let err =
       def= errors
     ; raiser=
         (fun e ->
-          log_backtrace () ;
           let exn = MemoryError e in
+          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/memory/memory_interface.ml
+++ b/ocaml/xapi-idl/memory/memory_interface.ml
@@ -88,7 +88,6 @@ let err =
     ; raiser=
         (fun e ->
           let exn = MemoryError e in
-          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -295,7 +295,6 @@ let err =
     ; raiser=
         (fun e ->
           let exn = Network_error e in
-          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -294,8 +294,8 @@ let err =
       def= errors
     ; raiser=
         (fun e ->
-          log_backtrace () ;
           let exn = Network_error e in
+          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/v6/v6_interface.ml
+++ b/ocaml/xapi-idl/v6/v6_interface.ml
@@ -112,7 +112,6 @@ let err =
     ; raiser=
         (fun e ->
           let exn = V6_error e in
-          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi-idl/v6/v6_interface.ml
+++ b/ocaml/xapi-idl/v6/v6_interface.ml
@@ -111,8 +111,8 @@ let err =
       def= errors
     ; raiser=
         (fun e ->
-          log_backtrace () ;
           let exn = V6_error e in
+          log_backtrace exn ;
           error "%s (%s)" (Printexc.to_string exn) __LOC__ ;
           raise exn
         )

--- a/ocaml/xapi/cancel_tasks.ml
+++ b/ocaml/xapi/cancel_tasks.ml
@@ -21,6 +21,7 @@ open D
 let safe_wrapper n f x =
   try f x
   with e ->
+    Backtrace.is_important e ;
     debug "Caught exception while cancelling tasks (%s): %s" n
       (ExnHelper.string_of_exn e) ;
     Debug.log_backtrace e (Backtrace.get e)

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -173,7 +173,7 @@ let update_pifs ~__context host pifs =
                 |> List.concat_map vifs_on_local_bridge
                 |> List.iter set_carrier
               with e ->
-                log_backtrace () ;
+                log_backtrace e ;
                 error "Failed to update VIF carrier flags for PIF: %s"
                   (ExnHelper.string_of_exn e)
             ) ;

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -162,6 +162,7 @@ let on_xapi_start ~__context =
       | Message_switch_failure ->
           [] (* no more logging *)
       | e ->
+          Backtrace.is_important e ;
           error "Unexpected error querying the message switch: %s"
             (Printexc.to_string e) ;
           Debug.log_backtrace e (Backtrace.get e) ;

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -278,7 +278,7 @@ module MigrateLocal = struct
 
     let (module Remote) = get_remote_backend url verify_dest in
     (* Find the local VDI *)
-    let local_vdi = find_local_vdi ~dbg ~sr ~vdi in
+    let local_vdi, _ = find_vdi ~dbg ~sr ~vdi (module Local) in
     let mirror_id = State.mirror_id_of (sr, local_vdi.vdi) in
     debug "%s: Adding to active local mirrors before sending: id=%s"
       __FUNCTION__ mirror_id ;

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -346,14 +346,13 @@ let get_remote_backend url verify_dest =
   end)) in
   (module Remote : SMAPIv2)
 
-let find_local_vdi ~dbg ~sr ~vdi =
-  (* Find the local VDI *)
-  let vdis, _ = Local.SR.scan2 dbg sr in
+let find_vdi ~dbg ~sr ~vdi (module SMAPIv2 : SMAPIv2) =
+  let vdis, _ = SMAPIv2.SR.scan2 dbg sr in
   match List.find_opt (fun x -> x.vdi = vdi) vdis with
   | None ->
-      failwith "Local VDI not found"
+      failwith_fmt "VDI %s not found" (Storage_interface.Vdi.string_of vdi)
   | Some v ->
-      v
+      (v, vdis)
 
 (** [similar_vdis dbg sr vdi] returns a list of content_ids of vdis
   which are similar to the input [vdi] in [sr] *)

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -261,6 +261,7 @@ module Local : SMAPIv2
 
 val get_remote_backend : string -> bool -> (module SMAPIv2)
 
-val find_local_vdi : dbg:string -> sr:sr -> vdi:vdi -> vdi_info
+val find_vdi :
+  dbg:string -> sr:sr -> vdi:vdi -> (module SMAPIv2) -> vdi_info * vdi_info list
 
 val similar_vdis : dbg:string -> sr:sr -> vdi:vdi -> uuid list

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -19,6 +19,7 @@ module D = Debug.Make (struct let name = "mux" end)
 open D
 open Storage_interface
 open Storage_mux_reg
+open Storage_utils
 
 let s_of_sr = Storage_interface.Sr.string_of
 
@@ -329,28 +330,6 @@ module Mux = struct
         ) ;
       Storage_migrate.update_snapshot_info_src ~dbg:(Debug_info.to_string di)
         ~sr ~vdi ~url ~dest ~dest_vdi ~snapshot_pairs
-
-    exception No_VDI
-
-    (* Find a VDI given a storage-layer SR and VDI *)
-    let find_vdi ~__context sr vdi =
-      let sr = s_of_sr sr in
-      let vdi = s_of_vdi vdi in
-      let open Xapi_database.Db_filter_types in
-      let sr = Db.SR.get_by_uuid ~__context ~uuid:sr in
-      match
-        Db.VDI.get_records_where ~__context
-          ~expr:
-            (And
-               ( Eq (Field "location", Literal vdi)
-               , Eq (Field "SR", Literal (Ref.string_of sr))
-               )
-            )
-      with
-      | x :: _ ->
-          x
-      | _ ->
-          raise No_VDI
 
     let set_is_a_snapshot _context ~dbg ~sr ~vdi ~is_a_snapshot =
       Server_helpers.exec_with_new_task "VDI.set_is_a_snapshot"

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -372,7 +372,7 @@ module Mux = struct
         ) ;
       Server_helpers.exec_with_new_task "SR.update_snapshot_info_dest"
         ~subtask_of:(Ref.of_string dbg) (fun __context ->
-          let local_vdis = scan () ~dbg ~sr in
+          let local_vdis, _ = scan2 () ~dbg ~sr in
           let find_sm_vdi ~vdi ~vdi_info_list =
             try List.find (fun x -> x.vdi = vdi) vdi_info_list
             with Not_found ->

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -18,8 +18,7 @@ open D
 module Date = Clock.Date
 module XenAPI = Client.Client
 open Storage_interface
-
-exception No_VDI
+open Storage_utils
 
 let s_of_vdi = Vdi.string_of
 
@@ -29,26 +28,6 @@ let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let with_dbg ~name ~dbg f =
   Debug_info.with_dbg ~module_name:"SMAPIv1" ~name ~dbg f
-
-(* Find a VDI given a storage-layer SR and VDI *)
-let find_vdi ~__context sr vdi =
-  let sr = s_of_sr sr in
-  let vdi = s_of_vdi vdi in
-  let open Xapi_database.Db_filter_types in
-  let sr = Db.SR.get_by_uuid ~__context ~uuid:sr in
-  match
-    Db.VDI.get_records_where ~__context
-      ~expr:
-        (And
-           ( Eq (Field "location", Literal vdi)
-           , Eq (Field "SR", Literal (Ref.string_of sr))
-           )
-        )
-  with
-  | x :: _ ->
-      x
-  | _ ->
-      raise No_VDI
 
 (* Find a VDI reference given a name *)
 let find_content ~__context ?sr name =

--- a/ocaml/xapi/storage_smapiv1.mli
+++ b/ocaml/xapi/storage_smapiv1.mli
@@ -20,7 +20,4 @@ val vdi_read_write : (Sr.t * Vdi.t, bool) Hashtbl.t
 
 val vdi_info_of_vdi_rec : Context.t -> API.vDI_t -> Storage_interface.vdi_info
 
-val find_vdi : __context:Context.t -> Sr.t -> Vdi.t -> [`VDI] Ref.t * API.vDI_t
-(** Find a VDI given a storage-layer SR and VDI *)
-
 module SMAPIv1 : Server_impl

--- a/ocaml/xapi/storage_utils.mli
+++ b/ocaml/xapi/storage_utils.mli
@@ -64,3 +64,12 @@ val rpc :
 
 val transform_storage_exn : (unit -> 'a) -> 'a
 (** [transform_storage_exn f] runs [f], rethrowing any storage error as a nice XenAPI error *)
+
+exception No_VDI
+
+val find_vdi :
+     __context:Context.t
+  -> Storage_interface.sr
+  -> Storage_interface.vdi
+  -> [`VDI] Ref.t * API.vDI_t
+(** Find a VDI given a storage-layer SR and VDI *)

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -96,7 +96,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
             ~pending_forget:[] ~pool_auto_join ~token_timeout
             ~token_timeout_coefficient ~current_operations:[]
             ~allowed_operations:[] ~cluster_config:[] ~other_config:[]
-            ~is_quorate:false ~quorum:0L ~live_hosts:0L ;
+            ~is_quorate:false ~quorum:0L ~live_hosts:0L ~expected_hosts:0L ;
           Db.Cluster_host.create ~__context ~ref:cluster_host_ref
             ~uuid:cluster_host_uuid ~cluster:cluster_ref ~host ~enabled:true
             ~pIF ~current_operations:[] ~allowed_operations:[] ~other_config:[]

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -516,6 +516,8 @@ module Watcher = struct
         Db.Cluster.set_quorum ~__context ~self:cluster
           ~value:(Int64.of_int diag.quorum) ;
         Db.Cluster.set_live_hosts ~__context ~self:cluster
+          ~value:(Int64.of_int diag.total_votes) ;
+        Db.Cluster.set_expected_hosts ~__context ~self:cluster
           ~value:(Int64.of_int diag.total_votes)
     | Error (InternalError message) | Error (Unix_error message) ->
         warn "%s Cannot query diagnostics due to %s, not performing update"

--- a/ocaml/xapi/xapi_extensions.ml
+++ b/ocaml/xapi/xapi_extensions.ml
@@ -79,6 +79,7 @@ let call_extension rpc =
   | Api_errors.Server_error (code, params) ->
       API.response_of_failure code params
   | e ->
+      Backtrace.is_important e ;
       error "Unexpected exception calling extension %s: %s" rpc.Rpc.name
         (Printexc.to_string e) ;
       Debug.log_backtrace e (Backtrace.get e) ;

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -527,7 +527,7 @@ module Monitor = struct
                   Xapi_ha_vm_failover.restart_auto_run_vms ~__context
                     liveset_refs to_tolerate
                 with e ->
-                  log_backtrace () ;
+                  log_backtrace e ;
                   error
                     "Caught unexpected exception when executing restart plan: \
                      %s"
@@ -832,7 +832,7 @@ module Monitor = struct
                       )
                 )
               with e ->
-                log_backtrace () ;
+                log_backtrace e ;
                 debug "Exception in HA monitor thread: %s"
                   (ExnHelper.string_of_exn e) ;
                 Thread.delay !Xapi_globs.ha_monitor_interval

--- a/ocaml/xapi/xapi_observer_components.ml
+++ b/ocaml/xapi/xapi_observer_components.ml
@@ -91,13 +91,13 @@ let is_component_enabled ~component =
             )
             observers
         with e ->
-          D.log_backtrace () ;
+          D.log_backtrace e ;
           D.warn "is_component_enabled(%s) inner got exception: %s"
             (to_string component) (Printexc.to_string e) ;
           false
       )
   with e ->
-    D.log_backtrace () ;
+    D.log_backtrace e ;
     D.warn "is_component_enabled(%s) got exception: %s" (to_string component)
       (Printexc.to_string e) ;
     false

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1358,6 +1358,7 @@ let create_or_get_secret_on_master __context rpc session_id (_secret_ref, secret
 let protect_exn f x =
   try Some (f x)
   with e ->
+    Backtrace.is_important e ;
     debug "Ignoring exception: %s" (Printexc.to_string e) ;
     Debug.log_backtrace e (Backtrace.get e) ;
     None

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -196,7 +196,7 @@ let put_handler (req : Http.Request.t) s _ =
           http_proxy_to_plugin req s name
       | [""; services; "SM"; "data"; sr; vdi] when services = _services ->
           let vdi, _ =
-            Storage_smapiv1.find_vdi ~__context
+            Storage_utils.find_vdi ~__context
               (Storage_interface.Sr.of_string sr)
               (Storage_interface.Vdi.of_string vdi)
           in

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
@@ -299,7 +299,7 @@ let update_rrds uuid_domids paused_vms plugins_dss =
           reset_missing_data sr_rrdi.rrd missing_updates ;
 
           Hashtbl.replace sr_rrds sr_uuid sr_rrdi
-        with _ -> log_backtrace ()
+        with e -> log_backtrace e
       in
       let process_host plugins_dss available_dss =
         let host_rrdi = !host_rrd in

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
@@ -692,10 +692,10 @@ module Plugin = struct
           (* reset skip counts *)
           payload
         with e -> (
+          Backtrace.is_important e ;
           incr_skip_count uid plugin ;
           (* increase skip count *)
           let log e =
-            Backtrace.is_important e ;
             info "Failed to process plugin metrics file: %s (%s)"
               (P.string_of_uid ~uid) (Printexc.to_string e) ;
             log_backtrace e

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
@@ -300,7 +300,7 @@ let migrate_rrd (session_id : string option) (remote_address : string)
           Some x
       | None ->
           debug "VM %s RRDs not found on migrate! Continuing anyway..." vm_uuid ;
-          log_backtrace () ;
+          log_backtrace Not_found ;
           None
   )
   |> Option.iter (fun rrdi ->
@@ -696,9 +696,10 @@ module Plugin = struct
           incr_skip_count uid plugin ;
           (* increase skip count *)
           let log e =
+            Backtrace.is_important e ;
             info "Failed to process plugin metrics file: %s (%s)"
               (P.string_of_uid ~uid) (Printexc.to_string e) ;
-            log_backtrace ()
+            log_backtrace e
           in
           let open Rrd_protocol in
           match e with

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
@@ -300,7 +300,6 @@ let migrate_rrd (session_id : string option) (remote_address : string)
           Some x
       | None ->
           debug "VM %s RRDs not found on migrate! Continuing anyway..." vm_uuid ;
-          log_backtrace Not_found ;
           None
   )
   |> Option.iter (fun rrdi ->

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_shared.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_shared.ml
@@ -140,7 +140,7 @@ let send_rrd ?(session_id : string option)
   let open Xmlrpc_client in
   with_transport transport
     (with_http request (fun (_response, fd) ->
-         try Rrd_unix.to_fd ~internal:true rrd fd with _ -> log_backtrace ()
+         try Rrd_unix.to_fd ~internal:true rrd fd with e -> log_backtrace e
      )
     ) ;
   debug "Sending RRD complete."
@@ -171,7 +171,7 @@ let archive_rrd_internal ?(transport = None) ~uuid ~rrd () =
           Xapi_stdext_unix.Unixext.unlink_safe base_filename
         ) else
           debug "No local storage: not persisting RRDs"
-      with _ -> log_backtrace ()
+      with e -> log_backtrace e
     )
   | Some transport ->
       (* Stream it to the master to store, or maybe to a host in the migrate

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_stats.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_stats.ml
@@ -238,5 +238,6 @@ let print_snapshot () =
       print_stats ()
     )
   with e ->
+    Backtrace.is_important e ;
     debug "Caught: %s" (Printexc.to_string e) ;
-    log_backtrace ()
+    log_backtrace e

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -543,11 +543,12 @@ let monitor_write_loop writers =
               ) ;
               Thread.delay !Rrdd_shared.timeslice
             with e ->
+              Backtrace.is_important e ;
               warn
                 "Monitor/write thread caught an exception. Pausing for 10s, \
                  then restarting: %s"
                 (Printexc.to_string e) ;
-              log_backtrace () ;
+              log_backtrace e ;
               Thread.delay 10.
           done
       )

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -332,7 +332,10 @@ let refresh_phypath_to_sr_vdi () =
 let exec_tap_ctl_list () : ((string * string) * int) list =
   let tap_ctl = "/usr/sbin/tap-ctl list" in
   let extract_vdis pid minor _state kind phypath =
-    if not (kind = "vhd" || kind = "aio") then raise (Failure "Unknown type") ;
+    if not (kind = "vhd" || kind = "aio" || kind = "qcow2") then (
+      D.warn {|"%s" is not a known type.|} kind ;
+      raise (Failure "Unknown type")
+    ) ;
     (* Look up SR and VDI uuids from the physical path *)
     if not (Hashtbl.mem phypath_to_sr_vdi phypath) then
       refresh_phypath_to_sr_vdi () ;

--- a/ocaml/xenopsd/xc/mem_stats.ml
+++ b/ocaml/xenopsd/xc/mem_stats.ml
@@ -325,7 +325,7 @@ let generate_stats_exn () =
 let generate_stats () =
   try generate_stats_exn ()
   with e ->
-    D.log_backtrace () ;
+    D.log_backtrace e ;
     D.debug "Failed to generate stats: %s" (Printexc.to_string e) ;
     []
 


### PR DESCRIPTION
As XCP-ng is now supporting qcow2 file, xcp-rrdd-iostat generates an error like: `"/usr/sbin/tap-ctl list" returned a line that could not be parsed. Ignoring.`

This is because  `tap-ctl list` can return strings like:
  - "1564848    0    0      qcow2 /var/run/sr-mount/..."

This patch allows qcow2 type.