### PR TITLE
Update attach-static-vdis

### DIFF
--- a/scripts/attach-static-vdis
+++ b/scripts/attach-static-vdis
@@ -5,6 +5,10 @@
 STATE_DIR=/etc/xensource/static-vdis
 
 [ -d ${STATE_DIR} ] || exit 0
+if [ -z "$(find ${STATE_DIR} -mindepth 1)" ]; then
+   # directory is empty
+   exit 0
+fi
 [ -e /opt/xensource/bin/static-vdis ] || exit 0
 
 clear_stale_state(){


### PR DESCRIPTION
Fix failed service.

```
# reproduce it:
# /opt/xensource/libexec/attach-static-vdis start
Attempting to attach all statically-configured VDIscat: /etc/xensource/static-vdis/*/vdi-uuid: No such file or directory cat: /etc/xensource/static-vdis/*/vdi-uuid: No such file or directory
```
